### PR TITLE
Added support for Locale variants

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,8 +80,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -160,6 +165,11 @@
               <nexusUrl>https://oss.sonatype.org/</nexusUrl>
               <autoReleaseAfterClose>true</autoReleaseAfterClose>
             </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>2.22.2</version>
           </plugin>
         </plugins>
       </build>

--- a/src/main/java/at/porscheinformatik/weblate/spring/WeblateCodes.java
+++ b/src/main/java/at/porscheinformatik/weblate/spring/WeblateCodes.java
@@ -1,0 +1,80 @@
+package at.porscheinformatik.weblate.spring;
+
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class WeblateCodes {
+  private static final ConcurrentHashMap<Locale, String> weblateCodes = new ConcurrentHashMap<>();
+
+  private static final Pattern WEBLATE_LOCALE_PATTERN = Pattern.compile(
+    "^(?<lang>[a-z]{2,3})(?:_(?<script>[a-z]{4}))?(?:_(?<region>[a-z]{2}))?(?:_(?<variant>[a-z0-9-]{5,8})|@(?<xvariant>[a-z0-9-]{1,8}))?$", Pattern.CASE_INSENSITIVE);
+
+  /**
+   * resolves a WeblateCode for a given Locale
+   *
+   * @param locale
+   * @return WeblateCode or null if locale is not registered
+   */
+  public static String getCodeForLocale(Locale locale) {
+    return weblateCodes.getOrDefault(locale, null);
+  }
+
+  /**
+   * registers a Locale - WeblateCode pair.
+   *
+   * @param locale a unique non-null
+   * @param code   an WeblateCode
+   */
+  public static void registerLocale(Locale locale, String code) {
+    Objects.requireNonNull(locale);
+
+    if (Objects.isNull(code)) {
+      weblateCodes.remove(locale);
+    } else {
+      weblateCodes.put(locale, code);
+    }
+  }
+
+  /**
+   * attempts to derive and register a java.util.Locale from a given code.
+   *
+   * @return true when code is registered or could be registered, false when no locale could be derived or derived locale was already registered for another code
+   */
+  public static boolean deriveLocaleFromCode(String code) {
+    if (weblateCodes.containsValue(code)) {
+      return true;
+    }
+
+    final Matcher codeMatcher = WEBLATE_LOCALE_PATTERN.matcher(code);
+    if (codeMatcher.matches()) {
+      final Locale.Builder builder = new Locale.Builder();
+
+      builder.setLanguage(codeMatcher.group("lang"));
+
+      Optional.ofNullable(codeMatcher.group("script"))
+        .ifPresent(builder::setScript);
+
+      Optional.ofNullable(codeMatcher.group("region"))
+        .ifPresent(builder::setRegion);
+
+      Optional.ofNullable(codeMatcher.group("variant"))
+        .ifPresent(builder::setVariant);
+
+      // x-lvariant is special as normally variant must be 6-8 characters long, whereas lvariant can be shorter
+      Optional.ofNullable(codeMatcher.group("xvariant"))
+        .ifPresent(xvariant -> builder.setExtension('x', "lvariant-" + xvariant));
+
+      final Locale locale = builder.build();
+      if (!weblateCodes.containsKey(locale)) {
+        registerLocale(locale, code);
+        return true;
+      }
+    }
+
+    return false;
+  }
+}

--- a/src/main/java/at/porscheinformatik/weblate/spring/WeblateUtils.java
+++ b/src/main/java/at/porscheinformatik/weblate/spring/WeblateUtils.java
@@ -7,46 +7,19 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class WeblateCodes {
-  private static final ConcurrentHashMap<Locale, String> weblateCodes = new ConcurrentHashMap<>();
+public class WeblateUtils {
 
   private static final Pattern WEBLATE_LOCALE_PATTERN = Pattern.compile(
     "^(?<lang>[a-z]{2,3})(?:_(?<script>[a-z]{4}))?(?:_(?<region>[a-z]{2}))?(?:_(?<variant>[a-z0-9-]{5,8})|@(?<xvariant>[a-z0-9-]{1,8}))?$", Pattern.CASE_INSENSITIVE);
 
   /**
-   * resolves a WeblateCode for a given Locale
+   * Attempts to derive a {@link Locale} from a given code.
    *
-   * @param locale
-   * @return WeblateCode or null if locale is not registered
+   * @return the derived locale or null when no locale could be derived
    */
-  public static String getCodeForLocale(Locale locale) {
-    return weblateCodes.getOrDefault(locale, null);
-  }
-
-  /**
-   * registers a Locale - WeblateCode pair.
-   *
-   * @param locale a unique non-null
-   * @param code   an WeblateCode
-   */
-  public static void registerLocale(Locale locale, String code) {
-    Objects.requireNonNull(locale);
-
+  public static Locale deriveLocaleFromCode(String code) {
     if (Objects.isNull(code)) {
-      weblateCodes.remove(locale);
-    } else {
-      weblateCodes.put(locale, code);
-    }
-  }
-
-  /**
-   * attempts to derive and register a java.util.Locale from a given code.
-   *
-   * @return true when code is registered or could be registered, false when no locale could be derived or derived locale was already registered for another code
-   */
-  public static boolean deriveLocaleFromCode(String code) {
-    if (weblateCodes.containsValue(code)) {
-      return true;
+      return null;
     }
 
     final Matcher codeMatcher = WEBLATE_LOCALE_PATTERN.matcher(code);
@@ -68,13 +41,9 @@ public class WeblateCodes {
       Optional.ofNullable(codeMatcher.group("xvariant"))
         .ifPresent(xvariant -> builder.setExtension('x', "lvariant-" + xvariant));
 
-      final Locale locale = builder.build();
-      if (!weblateCodes.containsKey(locale)) {
-        registerLocale(locale, code);
-        return true;
-      }
+      return builder.build();
     }
 
-    return false;
+    return null;
   }
 }

--- a/src/main/java/at/porscheinformatik/weblate/spring/WeblateUtils.java
+++ b/src/main/java/at/porscheinformatik/weblate/spring/WeblateUtils.java
@@ -3,10 +3,12 @@ package at.porscheinformatik.weblate.spring;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+/**
+ * Utility class for handling Weblate locale codes.
+ */
 public class WeblateUtils {
 
   private static final Pattern WEBLATE_LOCALE_PATTERN = Pattern.compile(
@@ -15,6 +17,7 @@ public class WeblateUtils {
   /**
    * Attempts to derive a {@link Locale} from a given code.
    *
+   * @param code the code to derive from
    * @return the derived locale or null when no locale could be derived
    */
   public static Locale deriveLocaleFromCode(String code) {

--- a/src/test/java/at/porscheinformatik/weblate/spring/WeblateCodesTest.java
+++ b/src/test/java/at/porscheinformatik/weblate/spring/WeblateCodesTest.java
@@ -1,45 +1,37 @@
 package at.porscheinformatik.weblate.spring;
 
-import org.junit.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Locale;
+import java.util.stream.Stream;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 public class WeblateCodesTest {
 
-  @Test
-  public void validCodesToLocale() {
-    testCodeTolocale("de", Locale.GERMAN);
-    testCodeTolocale("en_GB", Locale.forLanguageTag("en-GB"));
-    testCodeTolocale("cz_hanz_ad", Locale.forLanguageTag("cz-hanz-ad"));
-    testCodeTolocale("en_devel", Locale.forLanguageTag("en-devel"));
-    testCodeTolocale("en_GB@test", Locale.forLanguageTag("en-gb-x-lvariant-test"));
-    testCodeTolocale("en_Cyri_UK@test", Locale.forLanguageTag("en-Cyri-UK-x-lvariant-test"));
-    testCodeTolocale("en_Cyri_UK@A", Locale.forLanguageTag("en-Cyri-UK-x-lvariant-A"));
+  @ParameterizedTest
+  @MethodSource("validCodesProvider")
+  void validCodesToLocale(String code, Locale locale) {
+    assertEquals(locale, WeblateUtils.deriveLocaleFromCode(code));
   }
 
-  @Test
-  public void noCodeFound() {
-    assertNull(WeblateCodes.getCodeForLocale(Locale.CANADA));
-  }
-
-  @Test
-  public void registerCodes() {
-    // codes "myalias" and "foo_baz" should be only available after they got registered
-    assertFalse(WeblateCodes.deriveLocaleFromCode("myalias"));
-    assertFalse(WeblateCodes.deriveLocaleFromCode("foo_baz"));
-
-    WeblateCodes.registerLocale(Locale.forLanguageTag("de-DE-myalias"), "myalias");
-    WeblateCodes.registerLocale(Locale.forLanguageTag("fo-BA-foobar"), "foo_baz");
-
-    testCodeTolocale("myalias", Locale.forLanguageTag("de-DE-myalias"));
-    testCodeTolocale("foo_baz", Locale.forLanguageTag("fo-BA-foobar"));
-  }
-
-  private void testCodeTolocale(String code, Locale locale) {
-    assertTrue(WeblateCodes.deriveLocaleFromCode(code));
-    assertEquals(code, WeblateCodes.getCodeForLocale(locale));
+  static Stream<Arguments> validCodesProvider() {
+    return Stream.of(
+      arguments(null, null),
+      arguments("de_hansel_AT", null), // scripts must be exact 4 char
+      arguments("de_AT@thisIsToLong", null),  // variants must be max 8 char
+      arguments("de_AT_test", null), // regular variants must be min 5 char
+      arguments("de", Locale.GERMAN),
+      arguments("en_GB", Locale.forLanguageTag("en-GB")),
+      arguments("cz_hanz_ad", Locale.forLanguageTag("cz-hanz-ad")),
+      arguments("en_devel", Locale.forLanguageTag("en-devel")),
+      arguments("en_GB@test", Locale.forLanguageTag("en-gb-x-lvariant-test")),
+      arguments("en_Cyri_UK@test", Locale.forLanguageTag("en-Cyri-UK-x-lvariant-test")),
+      arguments("en_Cyri_UK@A", Locale.forLanguageTag("en-Cyri-UK-x-lvariant-A"))
+    );
   }
 
 }

--- a/src/test/java/at/porscheinformatik/weblate/spring/WeblateCodesTest.java
+++ b/src/test/java/at/porscheinformatik/weblate/spring/WeblateCodesTest.java
@@ -1,0 +1,45 @@
+package at.porscheinformatik.weblate.spring;
+
+import org.junit.Test;
+
+import java.util.Locale;
+
+import static org.junit.Assert.*;
+
+public class WeblateCodesTest {
+
+  @Test
+  public void validCodesToLocale() {
+    testCodeTolocale("de", Locale.GERMAN);
+    testCodeTolocale("en_GB", Locale.forLanguageTag("en-GB"));
+    testCodeTolocale("cz_hanz_ad", Locale.forLanguageTag("cz-hanz-ad"));
+    testCodeTolocale("en_devel", Locale.forLanguageTag("en-devel"));
+    testCodeTolocale("en_GB@test", Locale.forLanguageTag("en-gb-x-lvariant-test"));
+    testCodeTolocale("en_Cyri_UK@test", Locale.forLanguageTag("en-Cyri-UK-x-lvariant-test"));
+    testCodeTolocale("en_Cyri_UK@A", Locale.forLanguageTag("en-Cyri-UK-x-lvariant-A"));
+  }
+
+  @Test
+  public void noCodeFound() {
+    assertNull(WeblateCodes.getCodeForLocale(Locale.CANADA));
+  }
+
+  @Test
+  public void registerCodes() {
+    // codes "myalias" and "foo_baz" should be only available after they got registered
+    assertFalse(WeblateCodes.deriveLocaleFromCode("myalias"));
+    assertFalse(WeblateCodes.deriveLocaleFromCode("foo_baz"));
+
+    WeblateCodes.registerLocale(Locale.forLanguageTag("de-DE-myalias"), "myalias");
+    WeblateCodes.registerLocale(Locale.forLanguageTag("fo-BA-foobar"), "foo_baz");
+
+    testCodeTolocale("myalias", Locale.forLanguageTag("de-DE-myalias"));
+    testCodeTolocale("foo_baz", Locale.forLanguageTag("fo-BA-foobar"));
+  }
+
+  private void testCodeTolocale(String code, Locale locale) {
+    assertTrue(WeblateCodes.deriveLocaleFromCode(code));
+    assertEquals(code, WeblateCodes.getCodeForLocale(locale));
+  }
+
+}

--- a/src/test/java/at/porscheinformatik/weblate/spring/WeblateMessageSourceTest.java
+++ b/src/test/java/at/porscheinformatik/weblate/spring/WeblateMessageSourceTest.java
@@ -1,7 +1,7 @@
 package at.porscheinformatik.weblate.spring;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -13,8 +13,8 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Locale;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
@@ -27,7 +27,7 @@ public class WeblateMessageSourceTest {
 
   private MockRestServiceServer mockServer;
 
-  @Before
+  @BeforeEach
   public void init() {
     messageSource = new WeblateMessageSource();
     messageSource.setRestTemplate(restTemplate);


### PR DESCRIPTION
WeblateMessageSource:
- changed Set<Locale> existingLocales to Set<String> existingCodes. 
This way locales can be registered after the codes are loaded. 
- variant and script translations are now loaded;

WeblateCodes:
- stores a map of Locales to weblate-codes
