### PR TITLE
fix: loading translations via changed date

### DIFF
--- a/src/main/java/at/porscheinformatik/weblate/spring/WeblateMessageSource.java
+++ b/src/main/java/at/porscheinformatik/weblate/spring/WeblateMessageSource.java
@@ -287,7 +287,11 @@ public class WeblateMessageSource extends AbstractMessageSource implements AllPr
   }
 
   private void loadTranslation(String code, Properties properties, long timestamp) {
-    String currentQuery = query + " AND changed:>=" + formatTimestampIso(timestamp);
+    String currentQuery = query;
+    if (timestamp > 0L) {
+      String timestampStr = formatTimestampIso(timestamp);
+      currentQuery += " AND (added:>=" + timestampStr + " OR changed:>=" + timestampStr + ")";
+    }
 
     try {
       RequestEntity<Void> request = RequestEntity


### PR DESCRIPTION
When using the units API and getting the translations via `"changed:>=YYYY-MM-DD"` you will not get all translations wanted. Translations which were only once touched get only an added date. So, those translations will not be fetched.

This changes query for the `changed` and `added` fields to fix this.

Fixes #43