### PR TITLE
Reuse cached entries if possible

### DIFF
--- a/src/test/java/at/porscheinformatik/weblate/spring/WeblateMessageSourceTest.java
+++ b/src/test/java/at/porscheinformatik/weblate/spring/WeblateMessageSourceTest.java
@@ -98,7 +98,6 @@ class WeblateMessageSourceTest {
   void simpleCase() {
     mockGetLocales();
     mockResponse(RESPONSE_OK);
-    mockResponse(RESPONSE_OK);
 
     String key1Value = messageSource.resolveCodeWithoutArguments("key1", Locale.ENGLISH);
     assertEquals(TEXT1, key1Value);


### PR DESCRIPTION
When loading e.g. de_DE then use the already cached entries for de.