### PR TITLE
chore: switch deployment to Maven Central

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           java-version: 17
           distribution: adopt
-          server-id: ossrh
+          server-id: central
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
       - name: Cache local Maven repository
@@ -32,8 +32,8 @@ jobs:
           echo "${{secrets.GPG_PRIVATE_KEY}}" > ~/.gnupg/gpg-key.asc
           gpg --no-tty --batch --yes --import ~/.gnupg/gpg-key.asc 
           rm ~/.gnupg/gpg-key.asc
-      - name: Deploy SNAPSHOT to Central
-        run: mvn -B deploy -Possrh -Dgpg.passphrase="${{secrets.GPG_PASSPHRASE}}"
+      - name: Deploy SNAPSHOT to Maven Central
+        run: mvn -B deploy -Pcentral -Dgpg.passphrase="${{secrets.GPG_PASSPHRASE}}"
         env:
-          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          MAVEN_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}

--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,38 @@
 
   <profiles>
     <profile>
+      <id>central</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>3.2.7</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>0.7.0</version>
+            <extensions>true</extensions>
+            <configuration>
+              <publishingServerId>central</publishingServerId>
+              <autoPublish>true</autoPublish>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
       <id>ossrh</id>
       <build>
         <plugins>


### PR DESCRIPTION
This pull request updates the Maven build and deployment configuration to switch from OSSRH to Maven Central. The changes include updating workflow files to use new credentials and server IDs, as well as adding a new Maven profile for publishing to Maven Central.

### Workflow configuration updates:
* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L17-R17): Updated `server-id` from `ossrh` to `central` and replaced OSSRH credentials (`OSSRH_USERNAME` and `OSSRH_PASSWORD`) with Maven Central credentials (`CENTRAL_USERNAME` and `CENTRAL_PASSWORD`). [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L17-R17) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L35-R39)

### Maven profile addition:
* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R170-R201): Added a new Maven profile with ID `central` to configure plugins for signing artifacts and publishing to Maven Central. This includes the `maven-gpg-plugin` for artifact signing and the `central-publishing-maven-plugin` for automated publishing.