### PR TITLE
fix: caching logic, always load asynchronous

### DIFF
--- a/src/main/java/at/porscheinformatik/weblate/spring/WeblateMessageSource.java
+++ b/src/main/java/at/porscheinformatik/weblate/spring/WeblateMessageSource.java
@@ -67,7 +67,19 @@ public class WeblateMessageSource extends AbstractMessageSource implements AllPr
   private Map<String, Locale> codeToLocale = new HashMap<>();
 
   private Map<Locale, String> existingLocales;
+  /**
+   * Cache keyed by exact Weblate-derived locale (e.g. {@code en}, {@code en_US}, {@code en_US_POSIX}).
+   * Each entry only holds the translations fetched for that specific language code.
+   * Entries are combined on read, so timestamps stay consistent per language code.
+   */
   private final Map<Locale, CacheEntry> translationsCache = new ConcurrentHashMap<>();
+  /**
+   * Merged view cache keyed by the requested locale (e.g. {@code en_US}).
+   * Built by combining all relevant per-code cache levels. Invalidated whenever any
+   * constituent level's timestamp has changed since the merge, so the hot path
+   * (all levels fresh) returns this directly without iterating any {@link Properties}.
+   */
+  private final Map<Locale, MergedCacheEntry> mergedCache = new ConcurrentHashMap<>();
   private final ExecutorService executor = Executors
       .newSingleThreadExecutor(r -> new Thread(r, "WeblateMessageSource"));
 
@@ -284,6 +296,7 @@ public class WeblateMessageSource extends AbstractMessageSource implements AllPr
     logger.info("Going to clear cache...");
     existingLocales = null;
     translationsCache.clear();
+    mergedCache.clear();
   }
 
   /**
@@ -321,42 +334,105 @@ public class WeblateMessageSource extends AbstractMessageSource implements AllPr
     keys.forEach(translationsCache::remove);
   }
 
+  /**
+   * Returns the combined translations for the given locale by merging cache entries
+   * for each locale level (language-only → language+country → full locale) in order
+   * of increasing specificity.  More specific entries take precedence.
+   *
+   * <p>Each locale level has its own {@link CacheEntry} with an independent timestamp,
+   * so delta-loading remains consistent: a country-specific cache entry is never
+   * polluted with a stale timestamp from the language-only level.</p>
+   */
   private Properties loadTranslations(Locale locale, boolean reload) {
-    CacheEntry cacheEntry = translationsCache.get(locale);
     long now = System.currentTimeMillis();
 
-    if (cacheEntry != null && !reload && cacheEntry.timestamp > now - maxAgeMilis) {
-      return cacheEntry.properties;
-    }
-
-    Properties properties = cacheEntry != null ? cacheEntry.properties : new Properties();
-    long oldTimestamp = cacheEntry != null ? cacheEntry.timestamp : initialCacheTimestamp;
-
-    cacheEntry = new CacheEntry(properties, now);
-
+    // Determine the locale levels to load, from least to most specific.
+    // Always at least the language-only level; optionally language+country and full locale.
     Locale languageOnly = new Locale(locale.getLanguage());
-    CacheEntry languageCacheEntry = translationsCache.get(languageOnly);
-    if (languageCacheEntry != null && !reload && languageCacheEntry.timestamp > now - maxAgeMilis) {
-      languageCacheEntry.properties.forEach(cacheEntry.properties::putIfAbsent);
-    } else {
-      loadTranslation(new Locale(locale.getLanguage()), cacheEntry.properties, oldTimestamp);
+    Locale languageAndCountry = StringUtils.hasText(locale.getCountry())
+        ? new Locale(locale.getLanguage(), locale.getCountry())
+        : null;
+    boolean hasVariantOrScript = StringUtils.hasText(locale.getVariant()) || StringUtils.hasText(locale.getScript());
+
+    // Refresh stale levels independently.
+    refreshCacheEntry(languageOnly, now, reload);
+    if (languageAndCountry != null && !languageOnly.equals(languageAndCountry)) {
+      refreshCacheEntry(languageAndCountry, now, reload);
+    }
+    if (hasVariantOrScript) {
+      refreshCacheEntry(locale, now, reload);
     }
 
-    if (StringUtils.hasText(locale.getCountry())) {
-      loadTranslation(new Locale(locale.getLanguage(), locale.getCountry()), cacheEntry.properties, oldTimestamp);
+    // Hot path: return the previously merged result if all constituent level cache
+    // entries are the same instances as when it was built (identity check catches both
+    // expiry-triggered refreshes and async loads that replaced a level entry).
+    MergedCacheEntry existing = mergedCache.get(locale);
+    if (existing != null && existing.isStillValid(translationsCache, languageOnly, languageAndCountry,
+        hasVariantOrScript ? locale : null)) {
+      return existing.properties;
     }
 
-    if (StringUtils.hasText(locale.getVariant()) || StringUtils.hasText(locale.getScript())) {
-      loadTranslation(locale, cacheEntry.properties, oldTimestamp);
+    // Build a fresh merge from least-specific to most-specific (later entries win).
+    Properties combined = new Properties();
+    mergeInto(combined, languageOnly);
+    if (languageAndCountry != null && !languageOnly.equals(languageAndCountry)) {
+      mergeInto(combined, languageAndCountry);
+    }
+    if (hasVariantOrScript) {
+      mergeInto(combined, locale);
     }
 
-    translationsCache.put(locale, cacheEntry);
+    mergedCache.put(locale, new MergedCacheEntry(combined, translationsCache, languageOnly,
+        languageAndCountry, hasVariantOrScript ? locale : null));
 
-    if (!async && cacheEntry.properties.size() == 0) {
+    if (!async && combined.isEmpty()) {
       logger.info("No translations available for locale " + locale);
     }
 
-    return cacheEntry.properties;
+    return combined;
+  }
+
+  /**
+   * Puts all entries from the cache for {@code level} into {@code target}.
+   * More-specific callers should invoke this <em>after</em> less-specific ones;
+   * existing keys in {@code target} are <em>overwritten</em> so that the most-specific
+   * value always wins.
+   */
+  private void mergeInto(Properties target, Locale level) {
+    CacheEntry entry = translationsCache.get(level);
+    if (entry != null) {
+      target.putAll(entry.properties);
+    }
+  }
+
+  /**
+   * Ensures the {@link CacheEntry} for {@code level} is populated and up-to-date.
+   * If the entry is absent or expired (or a forced reload is requested) the
+   * translations for exactly this locale level are fetched from Weblate and the
+   * entry is replaced atomically.
+   */
+  private void refreshCacheEntry(Locale level, long now, boolean reload) {
+    CacheEntry existing = translationsCache.get(level);
+
+    if (existing != null && !reload && existing.timestamp > now - maxAgeMilis) {
+      return; // still fresh
+    }
+
+    long oldTimestamp = existing != null ? existing.timestamp : initialCacheTimestamp;
+
+    // Start with a flat copy of the previously cached properties so that delta-loading
+    // (which only returns changed/added entries) can add on top without losing old data.
+    Properties copy = new Properties();
+    if (existing != null) {
+      copy.putAll(existing.properties);
+    }
+
+    // Replace the entry with the current timestamp before loading so that concurrent
+    // requests see a "loading in progress" entry rather than triggering duplicate loads.
+    CacheEntry updated = new CacheEntry(copy, now);
+    translationsCache.put(level, updated);
+
+    loadTranslation(level, updated.properties, oldTimestamp);
   }
 
   /**
@@ -379,6 +455,13 @@ public class WeblateMessageSource extends AbstractMessageSource implements AllPr
     }).handle((val, e) -> {
       if (e != null) {
         logger.warn("Error loading translation for locale " + language, e);
+      }
+      // Replace the CacheEntry with a fresh instance so that identity-based checks in
+      // MergedCacheEntry.isStillValid() detect the completion of this load and force a
+      // merged-cache rebuild on the next read (important for async mode).
+      CacheEntry current = translationsCache.get(language);
+      if (current != null) {
+        translationsCache.put(language, new CacheEntry(current.properties, current.timestamp));
       }
       return val;
     });
@@ -584,5 +667,58 @@ class CacheEntry {
   CacheEntry(Properties properties, long timestamp) {
     this.properties = properties;
     this.timestamp = timestamp;
+  }
+}
+
+/**
+ * Cached merged view for a specific requested locale (e.g. {@code en_US}).
+ * Stores the merged {@link Properties} together with the identity of the
+ * per-code {@link CacheEntry} levels used to build it.
+ * <p>
+ * The merged result is valid as long as every constituent level's current
+ * {@link CacheEntry} instance in {@code translationsCache} is the same object
+ * as the one used at build time.  {@code refreshCacheEntry} always puts a new
+ * {@link CacheEntry} instance when a level is refreshed, and {@code loadTranslation}
+ * replaces the entry (again with a new instance) once an async fetch completes.
+ * Either event causes {@link #isStillValid} to return {@code false}, forcing a rebuild.
+ */
+class MergedCacheEntry {
+  final Properties properties;
+  /** Snapshot of per-level CacheEntry instances at merge time, keyed by locale level. */
+  private final Map<Locale, CacheEntry> levelEntries;
+
+  MergedCacheEntry(Properties properties, Map<Locale, CacheEntry> translationsCache,
+      Locale languageOnly, Locale languageAndCountry, Locale full) {
+    this.properties = properties;
+    this.levelEntries = new HashMap<>();
+    snapshot(translationsCache, languageOnly);
+    if (languageAndCountry != null) {
+      snapshot(translationsCache, languageAndCountry);
+    }
+    if (full != null) {
+      snapshot(translationsCache, full);
+    }
+  }
+
+  private void snapshot(Map<Locale, CacheEntry> cache, Locale level) {
+    levelEntries.put(level, cache.get(level)); // may be null if level has no entry
+  }
+
+  boolean isStillValid(Map<Locale, CacheEntry> translationsCache,
+      Locale languageOnly, Locale languageAndCountry, Locale full) {
+    if (!sameEntry(translationsCache, languageOnly)) {
+      return false;
+    }
+    if (languageAndCountry != null && !sameEntry(translationsCache, languageAndCountry)) {
+      return false;
+    }
+    if (full != null && !sameEntry(translationsCache, full)) {
+      return false;
+    }
+    return true;
+  }
+
+  private boolean sameEntry(Map<Locale, CacheEntry> cache, Locale level) {
+    return cache.get(level) == levelEntries.get(level); // intentional identity check
   }
 }

--- a/src/main/java/at/porscheinformatik/weblate/spring/WeblateMessageSource.java
+++ b/src/main/java/at/porscheinformatik/weblate/spring/WeblateMessageSource.java
@@ -712,10 +712,7 @@ class MergedCacheEntry {
     if (languageAndCountry != null && !sameEntry(translationsCache, languageAndCountry)) {
       return false;
     }
-    if (full != null && !sameEntry(translationsCache, full)) {
-      return false;
-    }
-    return true;
+    return full == null || sameEntry(translationsCache, full);
   }
 
   private boolean sameEntry(Map<Locale, CacheEntry> cache, Locale level) {

--- a/src/test/java/at/porscheinformatik/weblate/spring/WeblateMessageSourceTest.java
+++ b/src/test/java/at/porscheinformatik/weblate/spring/WeblateMessageSourceTest.java
@@ -28,6 +28,7 @@ import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.test.web.client.response.DefaultResponseCreator;
 import org.springframework.web.client.RestTemplate;
 
+
 class WeblateMessageSourceTest {
 
   private static final String TEXT1 = "Hello, World!";
@@ -77,6 +78,34 @@ class WeblateMessageSourceTest {
             withStatus(status)
                 .contentType(MediaType.APPLICATION_JSON)
                 .body("[{\"code\":\"en\", \"translated\":1},{\"code\":\"de\"}]"));
+  }
+
+  private void mockGetLocalesWithCountry() {
+    mockServer.expect(ExpectedCount.once(),
+        requestTo("http://localhost:8080/api/projects/test-project/languages/")).andRespond(
+            withStatus(HttpStatus.OK)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body("[{\"code\":\"en\", \"translated\":1},{\"code\":\"en_US\", \"translated\":1}]"));
+  }
+
+  private void mockResponseForCode(String languageCode, String body) {
+    mockResponseForCode(languageCode, body, HttpStatus.OK);
+  }
+
+  private void mockResponseForCode(String languageCode, String body, HttpStatus status) {
+    try {
+      String url = "http://localhost:8080/api/translations/test-project/test-comp/" + languageCode + "/units/";
+      DefaultResponseCreator response = withStatus(status).contentType(MediaType.APPLICATION_JSON);
+      if (body != null) {
+        response.body(body);
+      }
+      mockServer.expect(ExpectedCount.once(),
+          requestTo(Matchers.startsWith(url)))
+          .andExpect(method(HttpMethod.GET))
+          .andRespond(response);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
   }
 
   private void mockResponse(String body) {
@@ -257,6 +286,68 @@ class WeblateMessageSourceTest {
     messageSource.getAllProperties(Locale.ENGLISH);
 
     assertEquals(properties, messageSource.getAllProperties(Locale.ENGLISH));
+  }
+
+  /**
+   * Verifies that each locale level (language-only vs. language+country) has its own
+   * independent cache entry and independent delta-loading timestamp.
+   * <p>
+   * When {@code en_US} is requested, the {@code en} and {@code en_US} caches are
+   * loaded independently.  After a cache timeout only the expired level is re-fetched
+   * with its own {@code oldTimestamp}, keeping the two levels consistent.
+   * Country-specific keys must override language-only keys.
+   */
+  @Test
+  @SuppressWarnings("java:S2925")
+  void perCodeCacheConsistency() throws Exception {
+    // "key1" exists in both en and en_US; "key2" only in en; "key3" only in en_US
+    String enResponse = "{\"count\":2,\"next\":null,\"previous\":null,\"results\":["
+        + "{\"id\":1,\"context\":\"key1\",\"target\":[\"en-key1\"]},"
+        + "{\"id\":2,\"context\":\"key2\",\"target\":[\"en-key2\"]}"
+        + "]}";
+    String enUsResponse = "{\"count\":2,\"next\":null,\"previous\":null,\"results\":["
+        + "{\"id\":1,\"context\":\"key1\",\"target\":[\"en_US-key1\"]},"
+        + "{\"id\":3,\"context\":\"key3\",\"target\":[\"en_US-key3\"]}"
+        + "]}";
+    String enResponseAfterTimeout = "{\"count\":1,\"next\":null,\"previous\":null,\"results\":["
+        + "{\"id\":2,\"context\":\"key2\",\"target\":[\"en-key2-updated\"]}"
+        + "]}";
+    String enUsResponseAfterTimeout = RESPONSE_EMPTY;
+
+    mockGetLocalesWithCountry();
+    mockResponseForCode("en", enResponse);
+    mockResponseForCode("en_US", enUsResponse);
+
+    Properties props = messageSource.getAllProperties(Locale.US);
+
+    // en_US key1 overrides en key1
+    assertEquals("en_US-key1", props.getProperty("key1"));
+    // key2 comes from en only
+    assertEquals("en-key2", props.getProperty("key2"));
+    // key3 comes from en_US only
+    assertEquals("en_US-key3", props.getProperty("key3"));
+
+    // Verify first phase, then reset the mock server so new expectations can be registered
+    mockServer.verify();
+    mockServer.reset();
+
+    // After timeout, both caches expire and are re-fetched independently with their
+    // own timestamps; the delta query filters by the previous load time.
+    messageSource.setMaxAgeMilis(100);
+    Thread.sleep(150);
+
+    // loadCodes is already cached – no further language list request expected.
+    // Only the two translation endpoints are hit again (delta load).
+    mockResponseForCode("en", enResponseAfterTimeout);
+    mockResponseForCode("en_US", enUsResponseAfterTimeout);
+
+    props = messageSource.getAllProperties(Locale.US);
+
+    // en-key2 was updated in the delta response
+    assertEquals("en-key2-updated", props.getProperty("key2"));
+    // en_US delta returned nothing new – key1 and key3 still come from previous cache
+    assertEquals("en_US-key1", props.getProperty("key1"));
+    assertEquals("en_US-key3", props.getProperty("key3"));
   }
 
 }


### PR DESCRIPTION
This pull request significantly improves the caching logic for locale-specific translations in `WeblateMessageSource`, ensuring that translations for each locale level (e.g., language-only, language+country, full locale) are cached and refreshed independently. The changes introduce a merged cache for efficient lookups, robust cache invalidation, and more reliable delta-loading, along with comprehensive tests to verify the new behavior.

**Caching improvements:**

* Added a new `mergedCache` to store merged translation views for requested locales, built from the current per-level caches and invalidated automatically when any constituent cache entry is refreshed. This allows for fast retrieval when all cache levels are fresh. [[1]](diffhunk://#diff-e6e2e9a1e6474a13280e549a3815db1af55e8967d5bbe7c53b5134dc588c3633R70-R82) [[2]](diffhunk://#diff-e6e2e9a1e6474a13280e549a3815db1af55e8967d5bbe7c53b5134dc588c3633R337-R435) [[3]](diffhunk://#diff-e6e2e9a1e6474a13280e549a3815db1af55e8967d5bbe7c53b5134dc588c3633R672-R721)
* Updated the cache clearing logic to also clear the new `mergedCache`, ensuring no stale merged entries remain after a reset.

**Cache consistency and delta-loading:**

* Refactored `loadTranslations` to independently refresh and merge cache entries for each locale level (language, language+country, variant/script), ensuring each level’s cache is managed and invalidated separately. This prevents stale data from one level affecting another and supports precise delta-loading.
* Ensured that after asynchronous translation loads, the relevant cache entry is replaced with a new instance, so merged caches are properly invalidated and rebuilt as needed.

**Testing enhancements:**

* Added a comprehensive test (`perCodeCacheConsistency`) to verify that each locale level maintains independent cache entries and timestamps, and that country-specific keys override language-only keys as expected. Also introduced helper methods for mocking locale and translation responses in tests. [[1]](diffhunk://#diff-49262be9904ed8093c0cf8c968237fcc529cdd337e38c9e5f87797f7c9c80886R83-R110) [[2]](diffhunk://#diff-49262be9904ed8093c0cf8c968237fcc529cdd337e38c9e5f87797f7c9c80886R291-R352)This pull request introduces a more robust caching mechanism for locale-based translations in `WeblateMessageSource`, ensuring independent cache entries and timestamps for each locale specificity level (language-only, language+country, full locale). This addresses potential issues with stale data and improves cache consistency, especially for country-specific overrides. The changes also add comprehensive tests to verify the new caching behavior.

### Caching improvements

* Added a new `mergedCache` to store merged translation properties for each requested locale, built from independent cache entries for each locale specificity level. This enables efficient reads and ensures consistency across cache levels.
* Refactored the `loadTranslations` method to merge translations from language-only, language+country, and full locale cache entries in order of specificity, with more specific entries taking precedence. Each cache level is refreshed independently, and merged cache entries are validated using identity checks.
* Introduced the `MergedCacheEntry` class to track merged properties and the identity of constituent cache entries, ensuring that merged results are invalidated and rebuilt when any underlying cache entry changes.
* Updated cache clearing logic to also clear the new `mergedCache`, ensuring full cache invalidation.
* Modified translation loading to replace cache entries with new instances after async loads, supporting correct merged cache invalidation.

### Testing enhancements

* Added a new test (`perCodeCacheConsistency`) to verify that each locale level maintains its own cache entry and timestamp, and that country-specific keys correctly override language-only keys. The test also checks independent delta-loading for each cache level after cache expiration.
* Introduced helper methods in the test suite to mock locale lists and translation responses for more granular testing of locale-specific caching.

Closes #92
