### PR TITLE
Add support for a default fallback locale

### DIFF
--- a/src/main/java/at/porscheinformatik/weblate/spring/WeblateMessageSource.java
+++ b/src/main/java/at/porscheinformatik/weblate/spring/WeblateMessageSource.java
@@ -65,6 +65,7 @@ public class WeblateMessageSource extends AbstractMessageSource implements AllPr
   private long initialCacheTimestamp = 0;
   private boolean async = false;
   private Map<String, Locale> codeToLocale = new HashMap<>();
+  private Locale defaultFallbackLocale;
 
   private Map<Locale, String> existingLocales;
   /**
@@ -280,6 +281,26 @@ public class WeblateMessageSource extends AbstractMessageSource implements AllPr
   }
 
   /**
+   * @return the default fallback locale that is used for loading translations that
+   * are not available in the requested locale, but are available in the default
+   * fallback locale. Default is null and thus disabled.
+   */
+  public Locale getDefaultFallbackLocale() {
+    return defaultFallbackLocale;
+  }
+
+  /**
+   * Set the default fallback locale that is used for loading translations that are
+   * not available in the requested locale, but are available in the default
+   * fallback locale. Set null to disable. Default is null and thus disabled.
+   *
+   * @param defaultFallbackLocale the default fallback locale
+   */
+  public void setDefaultFallbackLocale(Locale defaultFallbackLocale) {
+    this.defaultFallbackLocale = defaultFallbackLocale;
+  }
+
+  /**
    * Registers a manual mapping of a Weblate code to a {@link Locale}.
    *
    * @param code   the Weblate language code
@@ -355,6 +376,9 @@ public class WeblateMessageSource extends AbstractMessageSource implements AllPr
     boolean hasVariantOrScript = StringUtils.hasText(locale.getVariant()) || StringUtils.hasText(locale.getScript());
 
     // Refresh stale levels independently.
+    if (defaultFallbackLocale != null) {
+      refreshCacheEntry(defaultFallbackLocale, now, reload);
+    }
     refreshCacheEntry(languageOnly, now, reload);
     if (languageAndCountry != null && !languageOnly.equals(languageAndCountry)) {
       refreshCacheEntry(languageAndCountry, now, reload);

--- a/src/main/java/at/porscheinformatik/weblate/spring/WeblateMessageSource.java
+++ b/src/main/java/at/porscheinformatik/weblate/spring/WeblateMessageSource.java
@@ -10,6 +10,7 @@ import java.text.MessageFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -374,40 +375,39 @@ public class WeblateMessageSource extends AbstractMessageSource implements AllPr
         ? new Locale(locale.getLanguage(), locale.getCountry())
         : null;
     boolean hasVariantOrScript = StringUtils.hasText(locale.getVariant()) || StringUtils.hasText(locale.getScript());
+    Set<Locale> mergeLevels = new LinkedHashSet<>();
 
-    // Refresh stale levels independently.
     if (defaultFallbackLocale != null) {
-      refreshCacheEntry(defaultFallbackLocale, now, reload);
+      mergeLevels.add(defaultFallbackLocale);
     }
-    refreshCacheEntry(languageOnly, now, reload);
-    if (languageAndCountry != null && !languageOnly.equals(languageAndCountry)) {
-      refreshCacheEntry(languageAndCountry, now, reload);
+    mergeLevels.add(languageOnly);
+    if (languageAndCountry != null) {
+      mergeLevels.add(languageAndCountry);
     }
     if (hasVariantOrScript) {
-      refreshCacheEntry(locale, now, reload);
+      mergeLevels.add(locale);
+    }
+
+    // Refresh stale levels independently.
+    for (Locale level : mergeLevels) {
+      refreshCacheEntry(level, now, reload);
     }
 
     // Hot path: return the previously merged result if all constituent level cache
     // entries are the same instances as when it was built (identity check catches both
     // expiry-triggered refreshes and async loads that replaced a level entry).
     MergedCacheEntry existing = mergedCache.get(locale);
-    if (existing != null && existing.isStillValid(translationsCache, languageOnly, languageAndCountry,
-        hasVariantOrScript ? locale : null)) {
+    if (existing != null && existing.isStillValid(translationsCache, mergeLevels)) {
       return existing.properties;
     }
 
     // Build a fresh merge from least-specific to most-specific (later entries win).
     Properties combined = new Properties();
-    mergeInto(combined, languageOnly);
-    if (languageAndCountry != null && !languageOnly.equals(languageAndCountry)) {
-      mergeInto(combined, languageAndCountry);
-    }
-    if (hasVariantOrScript) {
-      mergeInto(combined, locale);
+    for (Locale level : mergeLevels) {
+      mergeInto(combined, level);
     }
 
-    mergedCache.put(locale, new MergedCacheEntry(combined, translationsCache, languageOnly,
-        languageAndCountry, hasVariantOrScript ? locale : null));
+    mergedCache.put(locale, new MergedCacheEntry(combined, translationsCache, mergeLevels));
 
     if (!async && combined.isEmpty()) {
       logger.info("No translations available for locale " + locale);
@@ -711,16 +711,11 @@ class MergedCacheEntry {
   /** Snapshot of per-level CacheEntry instances at merge time, keyed by locale level. */
   private final Map<Locale, CacheEntry> levelEntries;
 
-  MergedCacheEntry(Properties properties, Map<Locale, CacheEntry> translationsCache,
-      Locale languageOnly, Locale languageAndCountry, Locale full) {
+  MergedCacheEntry(Properties properties, Map<Locale, CacheEntry> translationsCache, Set<Locale> levels) {
     this.properties = properties;
     this.levelEntries = new HashMap<>();
-    snapshot(translationsCache, languageOnly);
-    if (languageAndCountry != null) {
-      snapshot(translationsCache, languageAndCountry);
-    }
-    if (full != null) {
-      snapshot(translationsCache, full);
+    for (Locale level : levels) {
+      snapshot(translationsCache, level);
     }
   }
 
@@ -728,15 +723,8 @@ class MergedCacheEntry {
     levelEntries.put(level, cache.get(level)); // may be null if level has no entry
   }
 
-  boolean isStillValid(Map<Locale, CacheEntry> translationsCache,
-      Locale languageOnly, Locale languageAndCountry, Locale full) {
-    if (!sameEntry(translationsCache, languageOnly)) {
-      return false;
-    }
-    if (languageAndCountry != null && !sameEntry(translationsCache, languageAndCountry)) {
-      return false;
-    }
-    return full == null || sameEntry(translationsCache, full);
+  boolean isStillValid(Map<Locale, CacheEntry> translationsCache, Set<Locale> levels) {
+    return levels.stream().allMatch(level -> sameEntry(translationsCache, level));
   }
 
   private boolean sameEntry(Map<Locale, CacheEntry> cache, Locale level) {

--- a/src/test/java/at/porscheinformatik/weblate/spring/WeblateMessageSourceTest.java
+++ b/src/test/java/at/porscheinformatik/weblate/spring/WeblateMessageSourceTest.java
@@ -88,6 +88,14 @@ class WeblateMessageSourceTest {
                 .body("[{\"code\":\"en\", \"translated\":1},{\"code\":\"en_US\", \"translated\":1}]"));
   }
 
+  private void mockGetLocalesWithFallback() {
+    mockServer.expect(ExpectedCount.once(),
+        requestTo("http://localhost:8080/api/projects/test-project/languages/")).andRespond(
+            withStatus(HttpStatus.OK)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body("[{\"code\":\"en\", \"translated\":1},{\"code\":\"de\", \"translated\":1}]"));
+  }
+
   private void mockResponseForCode(String languageCode, String body) {
     mockResponseForCode(languageCode, body, HttpStatus.OK);
   }
@@ -286,6 +294,29 @@ class WeblateMessageSourceTest {
     messageSource.getAllProperties(Locale.ENGLISH);
 
     assertEquals(properties, messageSource.getAllProperties(Locale.ENGLISH));
+  }
+
+  @Test
+  void defaultFallbackLocale() {
+    String enResponse = "{\"count\":2,\"next\":null,\"previous\":null,\"results\":["
+        + "{\"id\":1,\"context\":\"key1\",\"target\":[\"en-key1\"]},"
+        + "{\"id\":2,\"context\":\"key2\",\"target\":[\"en-key2\"]}"
+        + "]}";
+    String deResponse = "{\"count\":1,\"next\":null,\"previous\":null,\"results\":["
+        + "{\"id\":1,\"context\":\"key1\",\"target\":[\"de-key1\"]}"
+        + "]}";
+
+    messageSource.setDefaultFallbackLocale(Locale.ENGLISH);
+    mockGetLocalesWithFallback();
+    mockResponseForCode("en", enResponse);
+    mockResponseForCode("de", deResponse);
+
+    Properties allProperties = messageSource.getAllProperties(Locale.GERMAN);
+
+    assertEquals("de-key1", allProperties.getProperty("key1"));
+    assertEquals("en-key2", allProperties.getProperty("key2"));
+    assertEquals("de-key1", messageSource.resolveCodeWithoutArguments("key1", Locale.GERMAN));
+    assertEquals("en-key2", messageSource.resolveCodeWithoutArguments("key2", Locale.GERMAN));
   }
 
   /**


### PR DESCRIPTION
- Optional defaultFallbackLocale field that if set will be used as the first locale in the resolution chain
- Aim is to support setting some special locale like "en__devel" as recommended by weblate for "Developer (English)" as the locale and have it also supported for live translation reload